### PR TITLE
adding optimal parameters for sdxl

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ class Free_UNetModel(UNetModel):
 ### SD2.1 
 **b1**: 1.1, **b2**: 1.2, **s1**: 0.9, **s2**: 0.2
 
+### [SDXL](https://wandb.ai/nasirk24/UNET-FreeU-SDXL/reports/FreeU-SDXL-Optimal-Parameters--Vmlldzo1NDg4NTUw?accessToken=6745kr9rjd6e9yjevkr9bpd2lm6dpn6j00428gz5l60jrhl3gj4gubrz4aepupda) 
+**b1**: 1.1, **b2**: 1.2, **s1**: 0.6, **s2**: 0.4
+
 ### Range for More Parameters
 When trying additional parameters, consider the following ranges:
 - **b1**: 1 ≤ b1 ≤ 1.2


### PR DESCRIPTION
Did a large sweep over b and s parameters on SDXL - the default sd1.5/sd2.1 parameters were not playing so well

You can check out the [full report here](https://wandb.ai/nasirk24/UNET-FreeU-SDXL/reports/FreeU-SDXL-Optimal-Parameters--Vmlldzo1NDg4NTUw?accessToken=6745kr9rjd6e9yjevkr9bpd2lm6dpn6j00428gz5l60jrhl3gj4gubrz4aepupda) 

Here's a sample for the prompt from the website 'a boy playing pokemon'

**_Baseline SDXL_**

![b50e283a](https://github.com/ChenyangSi/FreeU/assets/29706203/5ca3d62a-c81e-42ec-b4e4-17ef5da2bb2c)

**_Selected parameters_**

![6ffff183](https://github.com/ChenyangSi/FreeU/assets/29706203/22f326b7-7e59-4473-a27e-8436be69885a)

